### PR TITLE
Fixed React import

### DIFF
--- a/debug-list-view.js
+++ b/debug-list-view.js
@@ -1,4 +1,5 @@
-import React, {
+import React from 'react';
+import {
   View,
   Text,
   StyleSheet,

--- a/debug-view.js
+++ b/debug-view.js
@@ -1,4 +1,5 @@
-import React, {View, StyleSheet} from 'react-native';
+import React from 'react';
+import {View, StyleSheet} from 'react-native';
 import DebugListView from './debug-list-view.js';
 import debugService from './debug-service';
 import debounce from 'debounce';


### PR DESCRIPTION
In the latest React-native releases, “React” should be importated from ‘react’ instead of ‘react-native’. This fix makes this plugin compatible with react-native >= 0.29