### PR TITLE
Additional props that are specified to LogView are now forwarded to the underlying ListView

### DIFF
--- a/debug-list-view.js
+++ b/debug-list-view.js
@@ -126,6 +126,7 @@ export default class Debug extends React.Component {
   }
 
   render() {
+    const {rows, ...props} = this.props;
     return (
       <View style={styles.container}>
         <View style={styles.toolBar}>
@@ -151,7 +152,8 @@ export default class Debug extends React.Component {
           <ListView
             ref={LISTVIEW_REF}
             dataSource={this.state.dataSource}
-            renderRow={this._renderRow.bind(this)}/>
+            renderRow={this._renderRow.bind(this)}
+            {...props} />
         </View>
       </View>
     );


### PR DESCRIPTION
This pull requests add support for forwarding additional props to the underlying ListView.

This for instance allows for fixing the annoying "empty sections are rendered..." bug.
Which can now be fixed by specifying:

```
<LogView enableEmptySections />
```