### PR TITLE
Fixed babel 7 compile error on RN56

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "json-stringify-safe": "^5.0.1",
-    "react-native-invertible-scroll-view": "^1.1.0",
+    "react-native-invertible-scroll-view": "^1.1.1",
     "moment": "^2.18.1",
     "debounce": "^1.0.2",
     "stacktrace-parser": "^0.1.4"


### PR DESCRIPTION
This pull-requests is necessary to build this project with react-native 0.56.0. It upgrades to 1.1.1 of `react-native-invertible-scroll-view` which fixes that specific compile error only.